### PR TITLE
Make django 1.11 compatible

### DIFF
--- a/djhallo/widgets.py
+++ b/djhallo/widgets.py
@@ -19,7 +19,7 @@ class HalloInput(forms.Textarea):
 
     def render(self, name, value, attrs=None):
         value = value or ''
-        final_attrs = self.build_attrs(attrs, name=name)
+        final_attrs = self.build_attrs(attrs, {"name": name})
         html = [
             '<div class="hallo-block"><article class="edit"></article><textarea%s>%s</textarea></div>' % \
             (flatatt(final_attrs), force_text(escape(value)))


### PR DESCRIPTION
As per the [Django 1.11 release notes](https://docs.djangoproject.com/en/dev/releases/1.11/#miscellaneous), the call signature for `build_attrs` changed.